### PR TITLE
fix Travis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.20.0" // ./gradlew dependencyUpdates
     }
-}
-
-plugins {
-    // ./gradlew dependencyUpdates
-    id 'com.github.ben-manes.versions' version '0.20.0'
 }
 
 allprojects {


### PR DESCRIPTION
to get rid of : all buildscript {} blocks must appear before any plugins {} blocks in the script